### PR TITLE
addition of compose yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,16 @@
+version: "3.2"
+
+services:
+  conan:
+    container_name: conan
+    build: .
+    restart: "unless-stopped"
+    volumes:
+      - /srv/conan/data:/home/steam/conan-dedicated
+    environment:
+      - PUID=1000
+      - PGID=1000
+    ports:
+      - 7777:7777/udp
+      - 7778:7778/udp
+      - 27015:27015/udp


### PR DESCRIPTION
This docker-compose.yaml will let someone be able to deploy the
container with one simple `docker-compose up -d` command.
